### PR TITLE
Make use of EnvVars in createFirewallRule step

### DIFF
--- a/src/main/java/io/jenkins/plugins/step/CreateFirewallRuleStep.java
+++ b/src/main/java/io/jenkins/plugins/step/CreateFirewallRuleStep.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.step;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.Run;
@@ -196,7 +197,7 @@ public class CreateFirewallRuleStep extends Step {
 
         @Override
         public Set<? extends Class<?>> getRequiredContext() {
-            return Set.of(Run.class, Launcher.class);
+            return Set.of(Run.class, Launcher.class, EnvVars.class);
         }
 
         @Override
@@ -302,7 +303,12 @@ public class CreateFirewallRuleStep extends Step {
                 cmd.add("--target-tags=" + step.getTargetTags());
             }
 
-            final var result = launcher.launch().cmds(cmd).quiet(true).join();
+            final var envVars = context.get(EnvVars.class);
+            final var starter = launcher.launch().cmds(cmd).quiet(true);
+            if (envVars != null) {
+                starter.envs(envVars);
+            }
+            final var result = starter.join();
 
             if (result != 0) {
                 throw new IllegalArgumentException("Failed to create a firewall rule with this command: " + cmd);

--- a/src/test/java/io/jenkins/plugins/step/CreateFirewallRuleStepTest.java
+++ b/src/test/java/io/jenkins/plugins/step/CreateFirewallRuleStepTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.Run;
 import hudson.util.ArgumentListBuilder;
@@ -24,6 +25,7 @@ import org.mockito.ArgumentCaptor;
 class CreateFirewallRuleStepTest {
 
     private final StepContext contextMock = mock(StepContext.class);
+    private final EnvVars envVarsMock = mock(EnvVars.class);
     private final Launcher launcherMock = mock(Launcher.class, RETURNS_DEEP_STUBS);
 
     private final CreateFirewallRuleStep step = new CreateFirewallRuleStep("test");
@@ -84,6 +86,23 @@ class CreateFirewallRuleStepTest {
                 .thenReturn(1);
 
         assertThrows(IllegalArgumentException.class, execution::run);
+    }
+
+    @Test
+    void testRunLauncherCommandWithEnvVars() throws Exception {
+        step.setAction("action");
+        when(contextMock.get(EnvVars.class)).thenReturn(envVarsMock);
+        final var execution = new CreateFirewallRuleStep.CreateFirewallRuleStepExecution(contextMock, step);
+
+        when(launcherMock
+                        .launch()
+                        .cmds(any(ArgumentListBuilder.class))
+                        .envs(envVarsMock)
+                        .quiet(true)
+                        .join())
+                .thenReturn(0);
+
+        assertDoesNotThrow(execution::run);
     }
 
     @Test


### PR DESCRIPTION
So that it can be executed as:

```
withGCP(credentialsId: "CREDS") {
    createFirewallRule(..)
}
```