### PR TITLE
Fix setting invalid GOOGLE_APPLICATION_CREDENTIALS env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The service account will need to have the necessary permissions to interact with
 
 ### withGCP
 This step will load the credentials file by the id and set the environment variables for the gcloud command to use.
-In particular, it will set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of the credentials file.
-And will also attempt to extract the `project_id` from the file and set it as `CLOUDSDK_CORE_PROJECT` environment variable.
+In particular, it will try to extract the `client_email` from the file and set it as `CLOUDSDK_CORE_ACCOUNT` environment variable.
+And it will also attempt to extract the `project_id` from the file and set it as `CLOUDSDK_CORE_PROJECT` environment variable.
 ```groovy
 withGCP(credentialsId: "credentials-id") {
     // run gcloud commands here

--- a/src/test/java/io/jenkins/plugins/step/WithGCPStepTest.java
+++ b/src/test/java/io/jenkins/plugins/step/WithGCPStepTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -28,7 +29,10 @@ import org.junit.jupiter.api.Test;
 
 class WithGCPStepTest {
     private static final String CREDENTIALS_ID = "id";
-    private static final String GOOGLE_APPLICATION_CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS";
+    private static final String CLOUDSDK_CORE_ACCOUNT = "CLOUDSDK_CORE_ACCOUNT";
+    private static final String CLOUDSDK_CORE_PROJECT = "CLOUDSDK_CORE_PROJECT";
+    private static final String ACCOUNT = "email";
+    private static final String PROJECT = "project";
 
     private final StepContext stepContextMock = mock(StepContext.class, RETURNS_DEEP_STUBS);
     private final Launcher launcherMock = mock(Launcher.class);
@@ -49,7 +53,8 @@ class WithGCPStepTest {
         when(procStarterMock.pwd(workspaceMock)).thenReturn(procStarterMock);
         when(procStarterMock.quiet(true)).thenReturn(procStarterMock);
         when(workspaceMock.createTempFile(anyString(), anyString())).thenReturn(tempFileMock);
-        when(tempFileMock.readToString()).thenReturn("{project_id: \"id\"}");
+        when(tempFileMock.readToString())
+                .thenReturn(String.format("{project_id: \"%s\", client_email: \"%s\"}", PROJECT, ACCOUNT));
         when(credentialsMock.getId()).thenReturn(CREDENTIALS_ID);
     }
 
@@ -91,7 +96,8 @@ class WithGCPStepTest {
             final var executionResult = result.start();
 
             assertThat(executionResult).isFalse();
-            verify(envVarsMock).put(GOOGLE_APPLICATION_CREDENTIALS, CREDENTIALS_ID);
+            verify(envVarsMock).put(CLOUDSDK_CORE_ACCOUNT, ACCOUNT);
+            verify(envVarsMock).put(CLOUDSDK_CORE_PROJECT, PROJECT);
         }
     }
 
@@ -111,7 +117,8 @@ class WithGCPStepTest {
             assertThat(result).isNotNull();
 
             assertThatCode(result::start).isInstanceOf(IllegalArgumentException.class);
-            verify(envVarsMock, never()).put(GOOGLE_APPLICATION_CREDENTIALS, CREDENTIALS_ID);
+            verify(envVarsMock, never()).put(eq(CLOUDSDK_CORE_ACCOUNT), any());
+            verify(envVarsMock, never()).put(eq(CLOUDSDK_CORE_PROJECT), any());
         }
     }
 


### PR DESCRIPTION

<!-- Please describe your pull request here. -->

The GOOGLE_APPLICATION_CREDENTIALS is set to credentialsId which is of no use (that variable should point to the credentials file itself)
Instead CLOUDSDK_CORE_ACCOUNT is set to the email of the service account

### Testing done

Modified Unit Tests

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
